### PR TITLE
Minimal quick-fix to support the new TRANSFER_SERVER_SEP0024 prop

### DIFF
--- a/src/stellar-toml.ts
+++ b/src/stellar-toml.ts
@@ -30,4 +30,5 @@ export type StellarTomlCurrency = Partial<{
 export type StellarToml = Partial<{
   CURRENCIES: StellarTomlCurrency[]
   TRANSFER_SERVER: string
+  TRANSFER_SERVER_SEP0024: string
 }>

--- a/src/transfer-server.ts
+++ b/src/transfer-server.ts
@@ -16,7 +16,11 @@ function fail(message: string): never {
 }
 
 function getTransferServerURL(stellarTomlData: StellarToml): string | null {
-  return stellarTomlData.TRANSFER_SERVER || null
+  return (
+    stellarTomlData.TRANSFER_SERVER_SEP0024 ||
+    stellarTomlData.TRANSFER_SERVER ||
+    null
+  )
 }
 
 export function TransferServer(


### PR DESCRIPTION
A proper solution would be to remember throughout the process if we followed the TRANSFER_SERVER_SEP0024 or the TRANSFER_SERVER link and disclose to the calling code whether it is a SEP-24 or a SEP-6 transfer server.