### PR TITLE
Rename debug logger

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,3 +1,3 @@
 import createDebugLogger from "debug"
 
-export const debug = createDebugLogger("sep-6")
+export const debug = createDebugLogger("stellar-transfer")


### PR DESCRIPTION
Enable debug logging now via `DEBUG=stellar-transfer`.